### PR TITLE
feat(DataSeeder): seed Admin role to the user Admin

### DIFF
--- a/P7CreateRestApi/Data/DataSeeder.cs
+++ b/P7CreateRestApi/Data/DataSeeder.cs
@@ -6,6 +6,7 @@ namespace Dot.Net.WebApi.Data
     [LogAspect]
     public static class DataSeeder
     {
+        
         public static async Task SeedAdmin(UserManager<User> userManager)
         {
             User? user = await userManager.FindByEmailAsync("admin@email.com");
@@ -27,6 +28,27 @@ namespace Dot.Net.WebApi.Data
                 if (!roleExist)
                 {
                     await roleManager.CreateAsync(new IdentityRole(roleName));
+                }
+            }
+        }
+
+        public static async Task SeedAdminRoles(UserManager<User> userManager, RoleManager<IdentityRole> roleManager)
+        {
+            // Vérifiez l'existence de l'utilisateur admin
+            User userAdmin = await userManager.FindByNameAsync("admin@email.com");
+            string[] roleNames = { "Admin", "User", "Trader" };
+
+            var result = await userManager.AddToRolesAsync(userAdmin, roleNames);
+            if (result.Succeeded)
+            {
+                Console.WriteLine("Les rôles ont été assignés avec succès.");
+            }
+            else
+            {
+                Console.WriteLine("Erreur lors de l'assignation des rôles :");
+                foreach (var error in result.Errors)
+                {
+                    Console.WriteLine($"- {error.Description}");
                 }
             }
         }

--- a/P7CreateRestApi/Program.cs
+++ b/P7CreateRestApi/Program.cs
@@ -5,6 +5,7 @@ using Dot.Net.WebApi.Services;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
@@ -19,9 +20,12 @@ builder.Services.AddDbContext<LocalDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
 
 // Add Identity
-builder.Services.AddIdentity<User, IdentityRole>(options => options.SignIn.RequireConfirmedAccount = true)
-    .AddEntityFrameworkStores<LocalDbContext>()
-    .AddDefaultTokenProviders();
+builder.Services.AddIdentity<User, IdentityRole>(options =>
+{
+    options.User.RequireUniqueEmail = true;
+})
+.AddEntityFrameworkStores<LocalDbContext>()
+.AddDefaultTokenProviders();
 
 // Add Authorization policies
 builder.Services.AddAuthorizationBuilder()
@@ -83,6 +87,7 @@ using (IServiceScope scope = app.Services.CreateScope())
         RoleManager<IdentityRole> roleManager = services.GetRequiredService<RoleManager<IdentityRole>>();
         await DataSeeder.SeedRoles(roleManager);
         await DataSeeder.SeedAdmin(userManager);
+        await DataSeeder.SeedAdminRoles(userManager, roleManager);
     }
     catch (Exception ex)
     {


### PR DESCRIPTION
- implement SeedAdminRoles in DataSeeder.cs and call it in Program.cs
- add options.User.RequireUniqueEmail = true to ensure that users with the same email address are not assigned roles from another user with the same email address

Resolve issue:
- The user seeded "Admin" does not have role #63