### PR TITLE
fix: LogToFile for APIASPECT is not writing in the file #80

### DIFF
--- a/P7CreateRestApi/Program.cs
+++ b/P7CreateRestApi/Program.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using Dot.Net.WebApi;
 using Dot.Net.WebApi.Data;
 using Dot.Net.WebApi.Domain;
 using Dot.Net.WebApi.Services;
@@ -13,6 +14,8 @@ WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 builder.Services.AddControllers();
+builder.Services.AddHttpContextAccessor();
+
 builder.Services.AddEndpointsApiExplorer();
 
 builder.Services.AddSwaggerGen(options =>
@@ -85,6 +88,9 @@ builder.Services.AddHostedService<TokenCleanupService>();
 builder.Services.AddScoped<ICurvePointService, CurvePointService>();
 
 WebApplication app = builder.Build();
+
+// Set the ServiceProvider for logging aspect
+ServiceProviderHelper.ServiceProvider = app.Services;
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())


### PR DESCRIPTION
- resolve logger initialization issues in PostSharp aspects
- ensure proper initialization of ServiceProviderHelper.ServiceProvider in Program.cs
- add checks for null logger and IHttpContextAccessor in LogApiCallAspect
- ensure logger and IHttpContextAccessor are correctly retrieved and used in LogApiCallAspect
- correct logging to file logic in LogApiCallAspect
- register IHttpContextAccessor service in Program.cs
- add additional logging for diagnostics in LogApiCallAspect
- improve logging messages

This also resolves the System.ArgumentNullException related to logger being null during API calls.