### PR TITLE
feat!(tests): comprehensive refactor of string property validation tests

### DIFF
--- a/P7CreateRestApi.Tests/BidListTests.cs
+++ b/P7CreateRestApi.Tests/BidListTests.cs
@@ -1,11 +1,14 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using Dot.Net.WebApi.Domain;
+using Microsoft.AspNetCore.Mvc.TagHelpers;
 
 namespace P7CreateRestApi.Tests;
 
 public class BidListTests
 {
+    // --------------- VALID DATA ------------------
+    // BidList with all valid data is declarated here because it will be used in all tests
     public BidList bidList = new()
     {
         BidListId = 1,
@@ -31,6 +34,7 @@ public class BidListTests
         SourceListId = "SourceListId",
         Side = "Side"
     };
+    // --------------- VALID DATA ------------------
 
     // ALL DATA VALID
     [Fact]
@@ -54,58 +58,7 @@ public class BidListTests
     [MemberData(nameof(SampleTestVariables.StringCombinationsTest), MemberType = typeof(SampleTestVariables))]
     public void Test_Validate_Account_StringVariation_ShouldReturnExpectedResults(string? input, int code)
     {
-        // Arrange
-        bidList.Account = input;
-        int i = 0;
-
-        var expectedMessages = new List<string>
-        {
-            "Account is mandatory",
-            "Account must be a string",
-            "Account can't be longer than 50 characters"
-        };
-
-        // Act
-        Exception? ex = Record.Exception(() => bidList.Validate());
-
-        // Assert
-        // [Required(ErrorMessage = "Account is mandatory")]
-        // [DataType(DataType.Text, ErrorMessage = "Account must be a string")]
-        if (SampleTestVariables.stringMandatory.Contains(code))
-        {
-            Assert.NotNull(ex);
-            Assert.IsType<ValidationException>(ex);
-            var validationException = (ValidationException)ex;
-
-            // Check if the exception message contains any of the expected messages
-            bool containsExpectedMessage = expectedMessages.Any(message => validationException.Message.Contains(message));
-
-            Assert.True(containsExpectedMessage, $"Expected one of the following messages: " +
-                $"\"Account is mandatory\",\r\n or \"Account must be a string\". Actual message: {validationException.Message}");
-        }
-        // [MaxLength(50, ErrorMessage = "Account can't be longer than 50 characters")]
-        else if (SampleTestVariables.moreThan51Char.Contains(code))
-        {
-            Assert.NotNull(ex);
-            Assert.IsType<ValidationException>(ex);
-            var validationException = (ValidationException)ex;
-
-            // Check if the exception message contains the length message
-            bool containsExpectedMessage = validationException.Message.Contains(expectedMessages[2]);
-
-            Assert.True(containsExpectedMessage, $"Expected message: {expectedMessages[2]}. Actual message: {validationException.Message}");
-        }
-        // Valid DATA
-        else if (SampleTestVariables.lessThan51Char.Contains(code))
-        {
-            Assert.Null(ex);
-            Assert.Equal(bidList.Account, input);
-        }
-        else
-        {
-            i++;
-            Assert.Fail($"Unexpected result {i} times {input}");
-        }
+        TestHelper.ValidateStringProperty(bidList, nameof(BidList.Account), input, code, instance => instance.Validate);
     }
 
     // BidType - 50 characters max - Mandatory
@@ -113,117 +66,15 @@ public class BidListTests
     [MemberData(nameof(SampleTestVariables.StringCombinationsTest), MemberType = typeof(SampleTestVariables))]
     public void Test_Validate_BidType_StringVariation_ShouldReturnExpectedResults(string? input, int code)
     {
-        // Arrange
-        bidList.BidType = input;
-        int i = 0;
-
-        var expectedMessages = new List<string>
-        {
-            "BidType is mandatory",
-            "BidType must be a string",
-            "BidType can't be longer than 50 characters"
-        };
-
-        // Act
-        Exception? ex = Record.Exception(() => bidList.Validate());
-
-        // Assert
-        // [Required(ErrorMessage = "BidType is mandatory")]
-        // [DataType(DataType.Text, ErrorMessage = "BidType must be a string")]
-        if (SampleTestVariables.stringMandatory.Contains(code))
-        {
-            Assert.NotNull(ex);
-            Assert.IsType<ValidationException>(ex);
-            var validationException = (ValidationException)ex;
-
-            // Check if the exception message contains any of the expected messages
-            bool containsExpectedMessage = expectedMessages.Any(message => validationException.Message.Contains(message));
-
-            Assert.True(containsExpectedMessage, $"Expected one of the following messages: " +
-                $"\"BidType is mandatory\",\r\n or \"BidType must be a string\". Actual message: {validationException.Message}");
-        }
-        // [MaxLength(50, ErrorMessage = "BidType can't be longer than 50 characters")]
-        else if (SampleTestVariables.moreThan51Char.Contains(code))
-        {
-            Assert.NotNull(ex);
-            Assert.IsType<ValidationException>(ex);
-            var validationException = (ValidationException)ex;
-
-            // Check if the exception message contains the length message
-            bool containsExpectedMessage = validationException.Message.Contains(expectedMessages[2]);
-
-            Assert.True(containsExpectedMessage, $"Expected message: {expectedMessages[2]}. Actual message: {validationException.Message}");
-        }
-        // Valid DATA
-        else if (SampleTestVariables.lessThan51Char.Contains(code))
-        {
-            Assert.Null(ex);
-            Assert.Equal(bidList.BidType, input);
-        }
-        else
-        {
-            i++;
-            Assert.Fail($"Unexpected result {i} times {input}");
-        }
+        TestHelper.ValidateStringProperty(bidList, nameof(BidList.BidType), input, code, instance => instance.Validate);
     }
 
-    // BenchMark - 100 characters max - Mandatory
+    // Benchmark - 100 characters max - Mandatory
     [Theory]
     [MemberData(nameof(SampleTestVariables.StringCombinationsTest), MemberType = typeof(SampleTestVariables))]
-    public void Test_Validate_BenchMark_StringVariation_ShouldReturnExpectedResults(string? input, int code)
+    public void Test_Validate_Benchmark_StringVariation_ShouldReturnExpectedResults(string? input, int code)
     {
-        // Arrange
-        bidList.Benchmark = input;
-        int i = 0;
-
-        var expectedMessages = new List<string>
-        {
-            "Benchmark is mandatory",
-            "Benchmark must be a string",
-            "Benchmark can't be longer than 100 characters"
-        };
-
-        // Act
-        Exception? ex = Record.Exception(() => bidList.Validate());
-
-        // Assert
-        // [Required(ErrorMessage = "Benchmark is mandatory")]
-        // [DataType(DataType.Text, ErrorMessage = "Benchmark must be a string")]
-        if (SampleTestVariables.stringMandatory.Contains(code))
-        {
-            Assert.NotNull(ex);
-            Assert.IsType<ValidationException>(ex);
-            var validationException = (ValidationException)ex;
-
-            // Check if the exception message contains any of the expected messages
-            bool containsExpectedMessage = expectedMessages.Any(message => validationException.Message.Contains(message));
-
-            Assert.True(containsExpectedMessage, $"Expected one of the following messages: " +
-                $"\"Benchmark is mandatory\",\r\n or \"Benchmark must be a string\". Actual message: {validationException.Message}");
-        }
-        // [MaxLength(100, ErrorMessage = "Benchmark can't be longer than 100 characters")]
-        else if (SampleTestVariables.moreThan101Char.Contains(code))
-        {
-            Assert.NotNull(ex);
-            Assert.IsType<ValidationException>(ex);
-            var validationException = (ValidationException)ex;
-
-            // Check if the exception message contains the length message
-            bool containsExpectedMessage = validationException.Message.Contains(expectedMessages[2]);
-
-            Assert.True(containsExpectedMessage, $"Expected message: {expectedMessages[2]}. Actual message: {validationException.Message}");
-        }
-        // Valid DATA
-        else if (SampleTestVariables.lessThan101Char.Contains(code))
-        {
-            Assert.Null(ex);
-            Assert.Equal(bidList.Benchmark, input);
-        }
-        else
-        {
-            i++;
-            Assert.Fail($"Unexpected result {i} times {input} with input {input}");
-        }
+        TestHelper.ValidateStringProperty(bidList, nameof(BidList.Benchmark), input, code, instance => instance.Validate);
     }
 
     // Commentary - 500 characters max - Mandatory
@@ -231,58 +82,7 @@ public class BidListTests
     [MemberData(nameof(SampleTestVariables.StringCombinationsTest), MemberType = typeof(SampleTestVariables))]
     public void Test_Validate_Commentary_StringVariation_ShouldReturnExpectedResults(string? input, int code)
     {
-        // Arrange
-        bidList.Commentary = input;
-        int i = 0;
-
-        var expectedMessages = new List<string>
-        {
-            "Commentary is mandatory",
-            "Commentary must be a string",
-            "Commentary can't be longer than 500 characters"
-        };
-
-        // Act
-        Exception? ex = Record.Exception(() => bidList.Validate());
-
-        // Assert
-        // [Required(ErrorMessage = "Commentary is mandatory")]
-        // [DataType(DataType.Text, ErrorMessage = "Commentary must be a string")]
-        if (SampleTestVariables.stringMandatory.Contains(code))
-        {
-            Assert.NotNull(ex);
-            Assert.IsType<ValidationException>(ex);
-            var validationException = (ValidationException)ex;
-
-            // Check if the exception message contains any of the expected messages
-            bool containsExpectedMessage = expectedMessages.Any(message => validationException.Message.Contains(message));
-
-            Assert.True(containsExpectedMessage, $"Expected one of the following messages: " +
-                $"\"Commentary is mandatory\",\r\n or \"Commentary must be a string\". Actual message: {validationException.Message}");
-        }
-        // [MaxLength(500, ErrorMessage = "Commentary can't be longer than 500 characters")]
-        else if (SampleTestVariables.moreThan501Char.Contains(code))
-        {
-            Assert.NotNull(ex);
-            Assert.IsType<ValidationException>(ex);
-            var validationException = (ValidationException)ex;
-
-            // Check if the exception message contains the length message
-            bool containsExpectedMessage = validationException.Message.Contains(expectedMessages[2]);
-
-            Assert.True(containsExpectedMessage, $"Expected message: {expectedMessages[2]}. Actual message: {validationException.Message}");
-        }
-        // Valid DATA
-        else if (SampleTestVariables.lessThan501Char.Contains(code))
-        {
-            Assert.Null(ex);
-            Assert.Equal(bidList.Commentary, input);
-        }
-        else
-        {
-            i++;
-            Assert.Fail($"Unexpected result {i} times {input} with input {input}");
-        }
+        TestHelper.ValidateStringProperty(bidList, nameof(BidList.Commentary), input, code, instance => instance.Validate);
     }
 
     // BidSecurity - 50 characters max - Mandatory
@@ -290,58 +90,7 @@ public class BidListTests
     [MemberData(nameof(SampleTestVariables.StringCombinationsTest), MemberType = typeof(SampleTestVariables))]
     public void Test_Validate_BidSecurity_StringVariation_ShouldReturnExpectedResults(string? input, int code)
     {
-        // Arrange
-        bidList.BidSecurity = input;
-        int i = 0;
-
-        var expectedMessages = new List<string>
-        {
-            "BidSecurity is mandatory",
-            "BidSecurity must be a string",
-            "BidSecurity can't be longer than 50 characters"
-        };
-
-        // Act
-        Exception? ex = Record.Exception(() => bidList.Validate());
-
-        // Assert
-        // [Required(ErrorMessage = "BidSecurity is mandatory")]
-        // [DataType(DataType.Text, ErrorMessage = "BidSecurity must be a string")]
-        if (SampleTestVariables.stringMandatory.Contains(code))
-        {
-            Assert.NotNull(ex);
-            Assert.IsType<ValidationException>(ex);
-            var validationException = (ValidationException)ex;
-
-            // Check if the exception message contains any of the expected messages
-            bool containsExpectedMessage = expectedMessages.Any(message => validationException.Message.Contains(message));
-
-            Assert.True(containsExpectedMessage, $"Expected one of the following messages: " +
-                $"\"BidSecurity is mandatory\",\r\n or \"BidSecurity must be a string\". Actual message: {validationException.Message}");
-        }
-        // [MaxLength(50, ErrorMessage = "BidSecurity can't be longer than 50 characters")]
-        else if (SampleTestVariables.moreThan51Char.Contains(code))
-        {
-            Assert.NotNull(ex);
-            Assert.IsType<ValidationException>(ex);
-            var validationException = (ValidationException)ex;
-
-            // Check if the exception message contains the length message
-            bool containsExpectedMessage = validationException.Message.Contains(expectedMessages[2]);
-
-            Assert.True(containsExpectedMessage, $"Expected message: {expectedMessages[2]}. Actual message: {validationException.Message}");
-        }
-        // Valid DATA
-        else if (SampleTestVariables.lessThan51Char.Contains(code))
-        {
-            Assert.Null(ex);
-            Assert.Equal(bidList.BidSecurity, input);
-        }
-        else
-        {
-            i++;
-            Assert.Fail($"Unexpected result {i} times {input}");
-        }
+        TestHelper.ValidateStringProperty(bidList, nameof(BidList.BidSecurity), input, code, instance => instance.Validate);
     }
 
     // BidStatus - 50 characters max - Mandatory
@@ -349,58 +98,7 @@ public class BidListTests
     [MemberData(nameof(SampleTestVariables.StringCombinationsTest), MemberType = typeof(SampleTestVariables))]
     public void Test_Validate_BidStatus_StringVariation_ShouldReturnExpectedResults(string? input, int code)
     {
-        // Arrange
-        bidList.BidStatus = input;
-        int i = 0;
-
-        var expectedMessages = new List<string>
-        {
-            "BidStatus is mandatory",
-            "BidStatus must be a string",
-            "BidStatus can't be longer than 50 characters"
-        };
-
-        // Act
-        Exception? ex = Record.Exception(() => bidList.Validate());
-
-        // Assert
-        // [Required(ErrorMessage = "BidStatus is mandatory")]
-        // [DataType(DataType.Text, ErrorMessage = "BidStatus must be a string")]
-        if (SampleTestVariables.stringMandatory.Contains(code))
-        {
-            Assert.NotNull(ex);
-            Assert.IsType<ValidationException>(ex);
-            var validationException = (ValidationException)ex;
-
-            // Check if the exception message contains any of the expected messages
-            bool containsExpectedMessage = expectedMessages.Any(message => validationException.Message.Contains(message));
-
-            Assert.True(containsExpectedMessage, $"Expected one of the following messages: " +
-                $"\"BidStatus is mandatory\",\r\n or \"BidStatus must be a string\". Actual message: {validationException.Message}");
-        }
-        // [MaxLength(50, ErrorMessage = "BidStatus can't be longer than 50 characters")]
-        else if (SampleTestVariables.moreThan51Char.Contains(code))
-        {
-            Assert.NotNull(ex);
-            Assert.IsType<ValidationException>(ex);
-            var validationException = (ValidationException)ex;
-
-            // Check if the exception message contains the length message
-            bool containsExpectedMessage = validationException.Message.Contains(expectedMessages[2]);
-
-            Assert.True(containsExpectedMessage, $"Expected message: {expectedMessages[2]}. Actual message: {validationException.Message}");
-        }
-        // Valid DATA
-        else if (SampleTestVariables.lessThan51Char.Contains(code))
-        {
-            Assert.Null(ex);
-            Assert.Equal(bidList.BidStatus, input);
-        }
-        else
-        {
-            i++;
-            Assert.Fail($"Unexpected result {i} times {input}");
-        }
+        TestHelper.ValidateStringProperty(bidList, nameof(BidList.BidStatus), input, code, instance => instance.Validate);
     }
 
     // Trader - 50 characters max - Mandatory
@@ -408,58 +106,7 @@ public class BidListTests
     [MemberData(nameof(SampleTestVariables.StringCombinationsTest), MemberType = typeof(SampleTestVariables))]
     public void Test_Validate_Trader_StringVariation_ShouldReturnExpectedResults(string? input, int code)
     {
-        // Arrange
-        bidList.Trader = input;
-        int i = 0;
-
-        var expectedMessages = new List<string>
-        {
-            "Trader is mandatory",
-            "Trader must be a string",
-            "Trader can't be longer than 50 characters"
-        };
-
-        // Act
-        Exception? ex = Record.Exception(() => bidList.Validate());
-
-        // Assert
-        // [Required(ErrorMessage = "Trader is mandatory")]
-        // [DataType(DataType.Text, ErrorMessage = "Trader must be a string")]
-        if (SampleTestVariables.stringMandatory.Contains(code))
-        {
-            Assert.NotNull(ex);
-            Assert.IsType<ValidationException>(ex);
-            var validationException = (ValidationException)ex;
-
-            // Check if the exception message contains any of the expected messages
-            bool containsExpectedMessage = expectedMessages.Any(message => validationException.Message.Contains(message));
-
-            Assert.True(containsExpectedMessage, $"Expected one of the following messages: " +
-                $"\"Trader is mandatory\",\r\n or \"Trader must be a string\". Actual message: {validationException.Message}");
-        }
-        // [MaxLength(50, ErrorMessage = "Trader can't be longer than 50 characters")]
-        else if (SampleTestVariables.moreThan51Char.Contains(code))
-        {
-            Assert.NotNull(ex);
-            Assert.IsType<ValidationException>(ex);
-            var validationException = (ValidationException)ex;
-
-            // Check if the exception message contains the length message
-            bool containsExpectedMessage = validationException.Message.Contains(expectedMessages[2]);
-
-            Assert.True(containsExpectedMessage, $"Expected message: {expectedMessages[2]}. Actual message: {validationException.Message}");
-        }
-        // Valid DATA
-        else if (SampleTestVariables.lessThan51Char.Contains(code))
-        {
-            Assert.Null(ex);
-            Assert.Equal(bidList.Trader, input);
-        }
-        else
-        {
-            i++;
-            Assert.Fail($"Unexpected result {i} times {input}");
-        }
+        TestHelper.ValidateStringProperty(bidList, nameof(BidList.Trader), input, code, instance => instance.Validate);
     }
 
     // Book - 50 characters max - Mandatory
@@ -467,58 +114,7 @@ public class BidListTests
     [MemberData(nameof(SampleTestVariables.StringCombinationsTest), MemberType = typeof(SampleTestVariables))]
     public void Test_Validate_Book_StringVariation_ShouldReturnExpectedResults(string? input, int code)
     {
-        // Arrange
-        bidList.Book = input;
-        int i = 0;
-
-        var expectedMessages = new List<string>
-        {
-            "Book is mandatory",
-            "Book must be a string",
-            "Book can't be longer than 50 characters"
-        };
-
-        // Act
-        Exception? ex = Record.Exception(() => bidList.Validate());
-
-        // Assert
-        // [Required(ErrorMessage = "Book is mandatory")]
-        // [DataType(DataType.Text, ErrorMessage = "Book must be a string")]
-        if (SampleTestVariables.stringMandatory.Contains(code))
-        {
-            Assert.NotNull(ex);
-            Assert.IsType<ValidationException>(ex);
-            var validationException = (ValidationException)ex;
-
-            // Check if the exception message contains any of the expected messages
-            bool containsExpectedMessage = expectedMessages.Any(message => validationException.Message.Contains(message));
-
-            Assert.True(containsExpectedMessage, $"Expected one of the following messages: " +
-                $"\"Book is mandatory\",\r\n or \"Book must be a string\". Actual message: {validationException.Message}");
-        }
-        // [MaxLength(50, ErrorMessage = "Book can't be longer than 50 characters")]
-        else if (SampleTestVariables.moreThan51Char.Contains(code))
-        {
-            Assert.NotNull(ex);
-            Assert.IsType<ValidationException>(ex);
-            var validationException = (ValidationException)ex;
-
-            // Check if the exception message contains the length message
-            bool containsExpectedMessage = validationException.Message.Contains(expectedMessages[2]);
-
-            Assert.True(containsExpectedMessage, $"Expected message: {expectedMessages[2]}. Actual message: {validationException.Message}");
-        }
-        // Valid DATA
-        else if (SampleTestVariables.lessThan51Char.Contains(code))
-        {
-            Assert.Null(ex);
-            Assert.Equal(bidList.Book, input);
-        }
-        else
-        {
-            i++;
-            Assert.Fail($"Unexpected result {i} times {input}");
-        }
+        TestHelper.ValidateStringProperty(bidList, nameof(BidList.Book), input, code, instance => instance.Validate);
     }
 
     // CreationName - 50 characters max - Mandatory
@@ -526,58 +122,7 @@ public class BidListTests
     [MemberData(nameof(SampleTestVariables.StringCombinationsTest), MemberType = typeof(SampleTestVariables))]
     public void Test_Validate_CreationName_StringVariation_ShouldReturnExpectedResults(string? input, int code)
     {
-        // Arrange
-        bidList.CreationName = input;
-        int i = 0;
-
-        var expectedMessages = new List<string>
-        {
-            "CreationName is mandatory",
-            "CreationName must be a string",
-            "CreationName can't be longer than 50 characters"
-        };
-
-        // Act
-        Exception? ex = Record.Exception(() => bidList.Validate());
-
-        // Assert
-        // [Required(ErrorMessage = "CreationName is mandatory")]
-        // [DataType(DataType.Text, ErrorMessage = "CreationName must be a string")]
-        if (SampleTestVariables.stringMandatory.Contains(code))
-        {
-            Assert.NotNull(ex);
-            Assert.IsType<ValidationException>(ex);
-            var validationException = (ValidationException)ex;
-
-            // Check if the exception message contains any of the expected messages
-            bool containsExpectedMessage = expectedMessages.Any(message => validationException.Message.Contains(message));
-
-            Assert.True(containsExpectedMessage, $"Expected one of the following messages: " +
-                $"\"CreationName is mandatory\",\r\n or \"CreationName must be a string\". Actual message: {validationException.Message}");
-        }
-        // [MaxLength(50, ErrorMessage = "CreationName can't be longer than 50 characters")]
-        else if (SampleTestVariables.moreThan51Char.Contains(code))
-        {
-            Assert.NotNull(ex);
-            Assert.IsType<ValidationException>(ex);
-            var validationException = (ValidationException)ex;
-
-            // Check if the exception message contains the length message
-            bool containsExpectedMessage = validationException.Message.Contains(expectedMessages[2]);
-
-            Assert.True(containsExpectedMessage, $"Expected message: {expectedMessages[2]}. Actual message: {validationException.Message}");
-        }
-        // Valid DATA
-        else if (SampleTestVariables.lessThan51Char.Contains(code))
-        {
-            Assert.Null(ex);
-            Assert.Equal(bidList.CreationName, input);
-        }
-        else
-        {
-            i++;
-            Assert.Fail($"Unexpected result {i} times {input}");
-        }
+        TestHelper.ValidateStringProperty(bidList, nameof(BidList.CreationName), input, code, instance => instance.Validate);
     }
 
     // RevisionName - 50 characters max - Mandatory
@@ -585,58 +130,7 @@ public class BidListTests
     [MemberData(nameof(SampleTestVariables.StringCombinationsTest), MemberType = typeof(SampleTestVariables))]
     public void Test_Validate_RevisionName_StringVariation_ShouldReturnExpectedResults(string? input, int code)
     {
-        // Arrange
-        bidList.RevisionName = input;
-        int i = 0;
-
-        var expectedMessages = new List<string>
-        {
-            "RevisionName is mandatory",
-            "RevisionName must be a string",
-            "RevisionName can't be longer than 50 characters"
-        };
-
-        // Act
-        Exception? ex = Record.Exception(() => bidList.Validate());
-
-        // Assert
-        // [Required(ErrorMessage = "RevisionName is mandatory")]
-        // [DataType(DataType.Text, ErrorMessage = "RevisionName must be a string")]
-        if (SampleTestVariables.stringMandatory.Contains(code))
-        {
-            Assert.NotNull(ex);
-            Assert.IsType<ValidationException>(ex);
-            var validationException = (ValidationException)ex;
-
-            // Check if the exception message contains any of the expected messages
-            bool containsExpectedMessage = expectedMessages.Any(message => validationException.Message.Contains(message));
-
-            Assert.True(containsExpectedMessage, $"Expected one of the following messages: " +
-                $"\"RevisionName is mandatory\",\r\n or \"RevisionName must be a string\". Actual message: {validationException.Message}");
-        }
-        // [MaxLength(50, ErrorMessage = "RevisionName can't be longer than 50 characters")]
-        else if (SampleTestVariables.moreThan51Char.Contains(code))
-        {
-            Assert.NotNull(ex);
-            Assert.IsType<ValidationException>(ex);
-            var validationException = (ValidationException)ex;
-
-            // Check if the exception message contains the length message
-            bool containsExpectedMessage = validationException.Message.Contains(expectedMessages[2]);
-
-            Assert.True(containsExpectedMessage, $"Expected message: {expectedMessages[2]}. Actual message: {validationException.Message}");
-        }
-        // Valid DATA
-        else if (SampleTestVariables.lessThan51Char.Contains(code))
-        {
-            Assert.Null(ex);
-            Assert.Equal(bidList.RevisionName, input);
-        }
-        else
-        {
-            i++;
-            Assert.Fail($"Unexpected result {i} times {input}");
-        }
+        TestHelper.ValidateStringProperty(bidList, nameof(BidList.RevisionName), input, code, instance => instance.Validate);
     }
 
     // DealName - 50 characters max - Mandatory
@@ -644,58 +138,7 @@ public class BidListTests
     [MemberData(nameof(SampleTestVariables.StringCombinationsTest), MemberType = typeof(SampleTestVariables))]
     public void Test_Validate_DealName_StringVariation_ShouldReturnExpectedResults(string? input, int code)
     {
-        // Arrange
-        bidList.DealName = input;
-        int i = 0;
-
-        var expectedMessages = new List<string>
-        {
-            "DealName is mandatory",
-            "DealName must be a string",
-            "DealName can't be longer than 50 characters"
-        };
-
-        // Act
-        Exception? ex = Record.Exception(() => bidList.Validate());
-
-        // Assert
-        // [Required(ErrorMessage = "DealName is mandatory")]
-        // [DataType(DataType.Text, ErrorMessage = "DealName must be a string")]
-        if (SampleTestVariables.stringMandatory.Contains(code))
-        {
-            Assert.NotNull(ex);
-            Assert.IsType<ValidationException>(ex);
-            var validationException = (ValidationException)ex;
-
-            // Check if the exception message contains any of the expected messages
-            bool containsExpectedMessage = expectedMessages.Any(message => validationException.Message.Contains(message));
-
-            Assert.True(containsExpectedMessage, $"Expected one of the following messages: " +
-                $"\"DealName is mandatory\",\r\n or \"DealName must be a string\". Actual message: {validationException.Message}");
-        }
-        // [MaxLength(50, ErrorMessage = "DealName can't be longer than 50 characters")]
-        else if (SampleTestVariables.moreThan51Char.Contains(code))
-        {
-            Assert.NotNull(ex);
-            Assert.IsType<ValidationException>(ex);
-            var validationException = (ValidationException)ex;
-
-            // Check if the exception message contains the length message
-            bool containsExpectedMessage = validationException.Message.Contains(expectedMessages[2]);
-
-            Assert.True(containsExpectedMessage, $"Expected message: {expectedMessages[2]}. Actual message: {validationException.Message}");
-        }
-        // Valid DATA
-        else if (SampleTestVariables.lessThan51Char.Contains(code))
-        {
-            Assert.Null(ex);
-            Assert.Equal(bidList.DealName, input);
-        }
-        else
-        {
-            i++;
-            Assert.Fail($"Unexpected result {i} times {input}");
-        }
+        TestHelper.ValidateStringProperty(bidList, nameof(BidList.DealName), input, code, instance => instance.Validate);
     }
 
     // SourceListId - 25 characters max - Mandatory
@@ -703,58 +146,7 @@ public class BidListTests
     [MemberData(nameof(SampleTestVariables.StringCombinationsTest), MemberType = typeof(SampleTestVariables))]
     public void Test_Validate_SourceListId_StringVariation_ShouldReturnExpectedResults(string? input, int code)
     {
-        // Arrange
-        bidList.SourceListId = input;
-        int i = 0;
-
-        var expectedMessages = new List<string>
-        {
-            "SourceListId is mandatory",
-            "SourceListId must be a string",
-            "SourceListId can't be longer than 25 characters"
-        };
-
-        // Act
-        Exception? ex = Record.Exception(() => bidList.Validate());
-
-        // Assert
-        // [Required(ErrorMessage = "SourceListId is mandatory")]
-        // [DataType(DataType.Text, ErrorMessage = "SourceListId must be a string")]
-        if (SampleTestVariables.stringMandatory.Contains(code))
-        {
-            Assert.NotNull(ex);
-            Assert.IsType<ValidationException>(ex);
-            var validationException = (ValidationException)ex;
-
-            // Check if the exception message contains any of the expected messages
-            bool containsExpectedMessage = expectedMessages.Any(message => validationException.Message.Contains(message));
-
-            Assert.True(containsExpectedMessage, $"Expected one of the following messages: " +
-                $"\"SourceListId is mandatory\",\r\n or \"SourceListId must be a string\". Actual message: {validationException.Message}");
-        }
-        // [MaxLength(25, ErrorMessage = "SourceListId can't be longer than 25 characters")]
-        else if (SampleTestVariables.moreThan51Char.Contains(code) || code == 345 || code == 3254)
-        {
-            Assert.NotNull(ex);
-            Assert.IsType<ValidationException>(ex);
-            var validationException = (ValidationException)ex;
-
-            // Check if the exception message contains the length message
-            bool containsExpectedMessage = validationException.Message.Contains(expectedMessages[2]);
-
-            Assert.True(containsExpectedMessage, $"Expected message: {expectedMessages[2]}. Actual message: {validationException.Message}");
-        }
-        // Valid DATA
-        else if (SampleTestVariables.lessThan25Char.Contains(code))
-        {
-            Assert.Null(ex);
-            Assert.Equal(bidList.SourceListId, input);
-        }
-        else
-        {
-            i++;
-            Assert.Fail($"Unexpected result {i} times {input}");
-        }
+        TestHelper.ValidateStringProperty(bidList, nameof(BidList.SourceListId), input, code, instance => instance.Validate);
     }
 
     // Side - 50 characters max - Mandatory
@@ -762,59 +154,9 @@ public class BidListTests
     [MemberData(nameof(SampleTestVariables.StringCombinationsTest), MemberType = typeof(SampleTestVariables))]
     public void Test_Validate_Side_StringVariation_ShouldReturnExpectedResults(string? input, int code)
     {
-        // Arrange
-        bidList.Side = input;
-        int i = 0;
-
-        var expectedMessages = new List<string>
-        {
-            "Side is mandatory",
-            "Side must be a string",
-            "Side can't be longer than 50 characters"
-        };
-
-        // Act
-        Exception? ex = Record.Exception(() => bidList.Validate());
-
-        // Assert
-        // [Required(ErrorMessage = "Side is mandatory")]
-        // [DataType(DataType.Text, ErrorMessage = "Side must be a string")]
-        if (SampleTestVariables.stringMandatory.Contains(code))
-        {
-            Assert.NotNull(ex);
-            Assert.IsType<ValidationException>(ex);
-            var validationException = (ValidationException)ex;
-
-            // Check if the exception message contains any of the expected messages
-            bool containsExpectedMessage = expectedMessages.Any(message => validationException.Message.Contains(message));
-
-            Assert.True(containsExpectedMessage, $"Expected one of the following messages: " +
-                $"\"Side is mandatory\",\r\n or \"Side must be a string\". Actual message: {validationException.Message}");
-        }
-        // [MaxLength(50, ErrorMessage = "Side can't be longer than 50 characters")]
-        else if (SampleTestVariables.moreThan51Char.Contains(code))
-        {
-            Assert.NotNull(ex);
-            Assert.IsType<ValidationException>(ex);
-            var validationException = (ValidationException)ex;
-
-            // Check if the exception message contains the length message
-            bool containsExpectedMessage = validationException.Message.Contains(expectedMessages[2]);
-
-            Assert.True(containsExpectedMessage, $"Expected message: {expectedMessages[2]}. Actual message: {validationException.Message}");
-        }
-        // Valid DATA
-        else if (SampleTestVariables.lessThan51Char.Contains(code))
-        {
-            Assert.Null(ex);
-            Assert.Equal(bidList.Side, input);
-        }
-        else
-        {
-            i++;
-            Assert.Fail($"Unexpected result {i} times {input}");
-        }
+        TestHelper.ValidateStringProperty(bidList, nameof(BidList.Side), input, code, instance => instance.Validate);
     }
+
 
     // --------------- STRING PROPERTIES TESTS ------------------
 

--- a/P7CreateRestApi.Tests/SampleTestVariables.cs
+++ b/P7CreateRestApi.Tests/SampleTestVariables.cs
@@ -76,14 +76,25 @@ public static class SampleTestVariables
     };
 
     public static readonly List<int?> stringMandatory = [0, 1, 2];
-    public static readonly List<int> moreThan51Char = [51, 101, 501, 514, 515, 512, 1014, 1015, 1012, 5014, 5015, 5012, 5145, 5124, 5125, 51254, 10145, 10124, 10125, 101254, 50145, 50124, 50125, 501254];
-    public static readonly List<int> moreThan101Char = [101, 1014, 1015, 1012, 10145, 10124, 10125, 101254, 501, 5014, 5015, 5012, 50145, 50124, 50125, 501254];
-    public static readonly List<int> moreThan501Char = [501, 5014, 5015, 5012, 50145, 50124, 50125, 501254];
     public static readonly List<int> containsSpecialChars = [5, 35, 515, 1015, 5015, 345, 325, 3254, 5145, 5125, 51254, 10145, 10125, 101254, 50145, 50125, 501254];
     public static readonly List<int> containsSpace = [2, 32, 512, 1012, 5012, 324, 325, 3254, 5124, 5125, 51254, 10124, 10125, 101254, 50124, 50125, 501254];
     public static readonly List<int> containsNumbers = [4, 34, 514, 1014, 5014, 345, 324, 3254, 5145, 5124, 51254, 10145, 10124, 101254, 50145, 50124, 501254];
-    public static readonly List<int> lessThan25Char = [3, 4, 5, 34, 32, 35, 324, 325]; // 345 : is 26 chars !
-    public static readonly List<int> lessThan51Char = [3, 4, 5, 34, 32, 35, 345, 324, 325, 3254];
-    public static readonly List<int> lessThan101Char = [3, 4, 5, 34, 32, 35, 51, 345, 324, 325, 3254, 514, 512, 515, 3254, 5125, 51254, 5124, 5145, 51245];
-    public static readonly List<int> lessThan501Char = [3, 4, 5, 34, 32, 35, 51, 345, 324, 325, 3254, 514, 512, 515, 3254, 5125, 51254, 5124, 5145, 51245, 101, 1014, 1012, 1015, 10145, 10124, 10125, 101254];
+
+    public static List<int> moreThanNChar(int maxLength)
+    {
+        return StringCombinationsTest
+            .Select(item => ((string)item[0], (int)item[1]))
+            .Where(entry => entry.Item1?.Length > maxLength)
+            .Select(entry => entry.Item2)
+            .ToList();
+    }
+
+    public static List<int> lessThanNChar(int maxLength)
+    {
+        return StringCombinationsTest
+            .Select(item => ((string)item[0], (int)item[1]))
+            .Where(entry => entry.Item1?.Length <= maxLength)
+            .Select(entry => entry.Item2)
+            .ToList();
+    }
 }

--- a/P7CreateRestApi.Tests/TestHelper.cs
+++ b/P7CreateRestApi.Tests/TestHelper.cs
@@ -1,0 +1,82 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+using Dot.Net.WebApi.Domain;
+
+namespace P7CreateRestApi.Tests;
+
+public static class TestHelper
+{
+    public static bool TryValidateObject(object obj, out List<ValidationResult> results)
+    {
+        ValidationContext context = new(obj);
+        results = new List<ValidationResult>();
+        return Validator.TryValidateObject(obj, context, results, true);
+    }
+
+    public static void ValidateStringProperty<T>(T instance, string propertyName, string? input, int code, Func<T, Action> validateMethod)
+    {
+        // Arrange
+        var property = typeof(T).GetProperty(propertyName);
+        property.SetValue(instance, input);
+
+        var expectedMessages = GetValidationMessages(property);
+        int maxLength = GetMaxLength(property);
+
+        // Act
+        Exception? ex = Record.Exception(() => validateMethod(instance)());
+
+        // Assert
+        if (SampleTestVariables.stringMandatory.Contains(code))
+        {
+            AssertValidationException(ex, expectedMessages.Take(2).ToList());
+        }
+        else if (SampleTestVariables.moreThanNChar(maxLength).Contains(code))
+        {
+            AssertValidationException(ex, expectedMessages.Skip(2).Take(1).ToList());
+        }
+        else if (SampleTestVariables.lessThanNChar(maxLength).Contains(code))
+        {
+            Assert.Null(ex);
+        }
+        else
+        {
+            Assert.Fail($"Unexpected result for input {input}");
+        }
+    }
+
+    public static List<string> GetValidationMessages(PropertyInfo property)
+    {
+        var attributes = property.GetCustomAttributes(typeof(ValidationAttribute), true);
+        return attributes.Select(attr => ((ValidationAttribute)attr).ErrorMessage).ToList();
+    }
+
+    public static void AssertValidationException(Exception? ex, List<string> expectedMessages)
+    {
+        Assert.NotNull(ex);
+        Assert.IsType<ValidationException>(ex);
+        var validationException = (ValidationException)ex;
+
+        bool containsExpectedMessage = expectedMessages.Any(message => validationException.Message.Contains(message));
+
+        Assert.True(containsExpectedMessage, $"Expected one of the following messages: {string.Join(", ", expectedMessages)}. Actual message: {validationException.Message}");
+    }
+
+
+    public static int GetMaxLength(PropertyInfo property)
+    {
+        var maxLengthAttribute = property.GetCustomAttribute<MaxLengthAttribute>();
+        if (maxLengthAttribute != null)
+        {
+            return maxLengthAttribute.Length;
+        }
+
+        var stringLengthAttribute = property.GetCustomAttribute<StringLengthAttribute>();
+        if (stringLengthAttribute != null)
+        {
+            return stringLengthAttribute.MaximumLength;
+        }
+
+        throw new InvalidOperationException($"The property '{property.Name}' does not have a MaxLength or StringLength attribute.");
+    }
+
+}

--- a/P7CreateRestApi.Tests/UserTests.cs
+++ b/P7CreateRestApi.Tests/UserTests.cs
@@ -54,7 +54,7 @@ public class UserTests
         user.Fullname = input;
 
         // Act
-        bool result = ValidationHelper.TryValidateObject(user, out List<ValidationResult>? validationResults);
+        bool result = TestHelper.TryValidateObject(user, out List<ValidationResult>? validationResults);
 
         // Assert
         if (resultExpected)


### PR DESCRIPTION
- implement ValidateStringProperty method to standardize string property validation across tests
- add GetMaxLength method to dynamically retrieve maximum length from MaxLength and StringLength attributes
- refactor test methods to utilize ValidateStringProperty, removing hardcoded max length values
- create moreThanNChar and lessThanNChar methods in SampleTestVariables for dynamic length filtering
- update tests for BidList properties to leverage the new validation infrastructure

**This change significantly improves the maintainability and flexibility of property validation tests by centralizing validation logic and automatically using the max length defined in data annotations. It lays the groundwork for future automation and consistent testing practices across different classes.**
