### PR TITLE
refactor(ValidateStringProperty): improve ValidateStringProperty by …

### DIFF
--- a/P7CreateRestApi.Tests/BidListTests.cs
+++ b/P7CreateRestApi.Tests/BidListTests.cs
@@ -58,7 +58,7 @@ public class BidListTests
     [MemberData(nameof(SampleTestVariables.StringCombinationsTest), MemberType = typeof(SampleTestVariables))]
     public void Test_Validate_Account_StringVariation_ShouldReturnExpectedResults(string? input, int code)
     {
-        TestHelper.ValidateStringProperty(bidList, nameof(BidList.Account), input, code, instance => instance.Validate);
+        TestHelper.ValidateStringProperty(bidList, nameof(BidList.Account), input, code, mandatory: true);
     }
 
     // BidType - 50 characters max - Mandatory
@@ -66,7 +66,7 @@ public class BidListTests
     [MemberData(nameof(SampleTestVariables.StringCombinationsTest), MemberType = typeof(SampleTestVariables))]
     public void Test_Validate_BidType_StringVariation_ShouldReturnExpectedResults(string? input, int code)
     {
-        TestHelper.ValidateStringProperty(bidList, nameof(BidList.BidType), input, code, instance => instance.Validate);
+        TestHelper.ValidateStringProperty(bidList, nameof(BidList.BidType), input, code, mandatory: true);
     }
 
     // Benchmark - 100 characters max - Mandatory
@@ -74,7 +74,7 @@ public class BidListTests
     [MemberData(nameof(SampleTestVariables.StringCombinationsTest), MemberType = typeof(SampleTestVariables))]
     public void Test_Validate_Benchmark_StringVariation_ShouldReturnExpectedResults(string? input, int code)
     {
-        TestHelper.ValidateStringProperty(bidList, nameof(BidList.Benchmark), input, code, instance => instance.Validate);
+        TestHelper.ValidateStringProperty(bidList, nameof(BidList.Benchmark), input, code, mandatory: true);
     }
 
     // Commentary - 500 characters max - Mandatory
@@ -82,7 +82,7 @@ public class BidListTests
     [MemberData(nameof(SampleTestVariables.StringCombinationsTest), MemberType = typeof(SampleTestVariables))]
     public void Test_Validate_Commentary_StringVariation_ShouldReturnExpectedResults(string? input, int code)
     {
-        TestHelper.ValidateStringProperty(bidList, nameof(BidList.Commentary), input, code, instance => instance.Validate);
+        TestHelper.ValidateStringProperty(bidList, nameof(BidList.Commentary), input, code, mandatory: true);
     }
 
     // BidSecurity - 50 characters max - Mandatory
@@ -90,7 +90,7 @@ public class BidListTests
     [MemberData(nameof(SampleTestVariables.StringCombinationsTest), MemberType = typeof(SampleTestVariables))]
     public void Test_Validate_BidSecurity_StringVariation_ShouldReturnExpectedResults(string? input, int code)
     {
-        TestHelper.ValidateStringProperty(bidList, nameof(BidList.BidSecurity), input, code, instance => instance.Validate);
+        TestHelper.ValidateStringProperty(bidList, nameof(BidList.BidSecurity), input, code, mandatory: true);
     }
 
     // BidStatus - 50 characters max - Mandatory
@@ -98,7 +98,7 @@ public class BidListTests
     [MemberData(nameof(SampleTestVariables.StringCombinationsTest), MemberType = typeof(SampleTestVariables))]
     public void Test_Validate_BidStatus_StringVariation_ShouldReturnExpectedResults(string? input, int code)
     {
-        TestHelper.ValidateStringProperty(bidList, nameof(BidList.BidStatus), input, code, instance => instance.Validate);
+        TestHelper.ValidateStringProperty(bidList, nameof(BidList.BidStatus), input, code, mandatory: true);
     }
 
     // Trader - 50 characters max - Mandatory
@@ -106,7 +106,7 @@ public class BidListTests
     [MemberData(nameof(SampleTestVariables.StringCombinationsTest), MemberType = typeof(SampleTestVariables))]
     public void Test_Validate_Trader_StringVariation_ShouldReturnExpectedResults(string? input, int code)
     {
-        TestHelper.ValidateStringProperty(bidList, nameof(BidList.Trader), input, code, instance => instance.Validate);
+        TestHelper.ValidateStringProperty(bidList, nameof(BidList.Trader), input, code, mandatory: true);
     }
 
     // Book - 50 characters max - Mandatory
@@ -114,7 +114,7 @@ public class BidListTests
     [MemberData(nameof(SampleTestVariables.StringCombinationsTest), MemberType = typeof(SampleTestVariables))]
     public void Test_Validate_Book_StringVariation_ShouldReturnExpectedResults(string? input, int code)
     {
-        TestHelper.ValidateStringProperty(bidList, nameof(BidList.Book), input, code, instance => instance.Validate);
+        TestHelper.ValidateStringProperty(bidList, nameof(BidList.Book), input, code, mandatory: true);
     }
 
     // CreationName - 50 characters max - Mandatory
@@ -122,7 +122,7 @@ public class BidListTests
     [MemberData(nameof(SampleTestVariables.StringCombinationsTest), MemberType = typeof(SampleTestVariables))]
     public void Test_Validate_CreationName_StringVariation_ShouldReturnExpectedResults(string? input, int code)
     {
-        TestHelper.ValidateStringProperty(bidList, nameof(BidList.CreationName), input, code, instance => instance.Validate);
+        TestHelper.ValidateStringProperty(bidList, nameof(BidList.CreationName), input, code, mandatory: true);
     }
 
     // RevisionName - 50 characters max - Mandatory
@@ -130,7 +130,7 @@ public class BidListTests
     [MemberData(nameof(SampleTestVariables.StringCombinationsTest), MemberType = typeof(SampleTestVariables))]
     public void Test_Validate_RevisionName_StringVariation_ShouldReturnExpectedResults(string? input, int code)
     {
-        TestHelper.ValidateStringProperty(bidList, nameof(BidList.RevisionName), input, code, instance => instance.Validate);
+        TestHelper.ValidateStringProperty(bidList, nameof(BidList.RevisionName), input, code, mandatory: true);
     }
 
     // DealName - 50 characters max - Mandatory
@@ -138,7 +138,7 @@ public class BidListTests
     [MemberData(nameof(SampleTestVariables.StringCombinationsTest), MemberType = typeof(SampleTestVariables))]
     public void Test_Validate_DealName_StringVariation_ShouldReturnExpectedResults(string? input, int code)
     {
-        TestHelper.ValidateStringProperty(bidList, nameof(BidList.DealName), input, code, instance => instance.Validate);
+        TestHelper.ValidateStringProperty(bidList, nameof(BidList.DealName), input, code, mandatory: true);
     }
 
     // SourceListId - 25 characters max - Mandatory
@@ -146,7 +146,7 @@ public class BidListTests
     [MemberData(nameof(SampleTestVariables.StringCombinationsTest), MemberType = typeof(SampleTestVariables))]
     public void Test_Validate_SourceListId_StringVariation_ShouldReturnExpectedResults(string? input, int code)
     {
-        TestHelper.ValidateStringProperty(bidList, nameof(BidList.SourceListId), input, code, instance => instance.Validate);
+        TestHelper.ValidateStringProperty(bidList, nameof(BidList.SourceListId), input, code, maxLength: 25, mandatory: true);
     }
 
     // Side - 50 characters max - Mandatory
@@ -154,9 +154,8 @@ public class BidListTests
     [MemberData(nameof(SampleTestVariables.StringCombinationsTest), MemberType = typeof(SampleTestVariables))]
     public void Test_Validate_Side_StringVariation_ShouldReturnExpectedResults(string? input, int code)
     {
-        TestHelper.ValidateStringProperty(bidList, nameof(BidList.Side), input, code, instance => instance.Validate);
+        TestHelper.ValidateStringProperty(bidList, nameof(BidList.Side), input, code, mandatory: true);
     }
-
 
     // --------------- STRING PROPERTIES TESTS ------------------
 

--- a/P7CreateRestApi.Tests/TestHelper.cs
+++ b/P7CreateRestApi.Tests/TestHelper.cs
@@ -13,36 +13,90 @@ public static class TestHelper
         return Validator.TryValidateObject(obj, context, results, true);
     }
 
-    public static void ValidateStringProperty<T>(T instance, string propertyName, string? input, int code, Func<T, Action> validateMethod)
+    /// <summary>
+    /// Validates a string property of an instance of a specified type.
+    /// </summary>
+    /// <typeparam name="T">The type of the instance.</typeparam>
+    /// <param name="instance">The instance whose property is to be validated.</param>
+    /// <param name="propertyName">The name of the string property to be validated.</param>
+    /// <param name="input">The input string to be validated.</param>
+    /// <param name="code">The expected validation code.</param>
+    /// <param name="validateMethod">The method used to validate the instance.</param>
+    /// <param name="minLength">The minimum length of the input string.</param>
+    /// <param name="maxLength">The maximum length of the input string. If null, the maximum length is retrieved from the property's validation attributes.</param>
+    /// <param name="mandatory">Indicates whether the input string is mandatory.</param>
+    /// <param name="NoSpecialChars">Indicates whether the input string should not contain special characters.</param>
+    /// <param name="NoNumbers">Indicates whether the input string should not contain numbers.</param>
+    public static void ValidateStringProperty<T>(
+        T instance,             
+        string propertyName,    
+        string? input,          
+        int code,               
+        int minLength = 0,      
+        int? maxLength = null,  
+        bool mandatory = false, 
+        bool NoSpecialChars = false, 
+        bool NoNumbers = false 
+    ) where T : IValidatable
     {
         // Arrange
+
+        // Get the property of the specified type and name
         var property = typeof(T).GetProperty(propertyName);
+
+        // Set the value of the property to the specified input string
         property.SetValue(instance, input);
 
+        // Get the expected validation messages for the property
         var expectedMessages = GetValidationMessages(property);
-        int maxLength = GetMaxLength(property);
+
+        // Get the effective maximum length of the input string
+        int effectiveMaxLength = maxLength ?? GetMaxLength(property);
 
         // Act
-        Exception? ex = Record.Exception(() => validateMethod(instance)());
+
+        // Try to validate the instance using the specified validation method
+        Exception? ex = Record.Exception(() => instance.Validate());
 
         // Assert
-        if (SampleTestVariables.stringMandatory.Contains(code))
+
+        // Check if the input string is mandatory and null or empty
+        if (mandatory && (input == null || input.Trim() == ""))
         {
-            AssertValidationException(ex, expectedMessages.Take(2).ToList());
+            // Assert that the validation exception contains the expected validation messages for mandatory input
+            AssertValidationException(ex, expectedMessages.Where(msg => msg.Contains($"{propertyName} is mandatory")).ToList());
         }
-        else if (SampleTestVariables.moreThanNChar(maxLength).Contains(code))
+        // Check if the length of the input string is less than the minimum length
+        else if (input != null && input.Length < minLength)
         {
-            AssertValidationException(ex, expectedMessages.Skip(2).Take(1).ToList());
+            // Assert that the validation exception contains the expected validation messages for minimum length violation
+            AssertValidationException(ex, expectedMessages.Where(msg => msg.Contains($"{propertyName} must be at least {minLength} characters long")).ToList());
         }
-        else if (SampleTestVariables.lessThanNChar(maxLength).Contains(code))
+        // Check if the length of the input string is greater than the effective maximum length
+        else if (input != null && input.Length > effectiveMaxLength)
+        {
+            // Assert that the validation exception contains the expected validation messages for maximum length violation
+            AssertValidationException(ex, expectedMessages.Where(msg => msg.Contains($"{propertyName} can't be longer than {effectiveMaxLength} characters")).ToList());
+        }
+        // Check if the input string contains special characters and NoSpecialChars is true
+        else if (NoSpecialChars && input != null && input.Any(ch => !char.IsLetterOrDigit(ch)))
+        {
+            // Assert that the validation exception contains the expected validation messages for special characters violation
+            AssertValidationException(ex, expectedMessages.Where(msg => msg.Contains($"{propertyName} should contain only letters and spaces")).ToList());
+        }
+        // Check if the input string contains numbers and NoNumbers is true
+        else if (NoNumbers && input != null && input.Any(ch => char.IsDigit(ch)))
+        {
+            // Assert that the validation exception contains the expected validation messages for numbers violation
+            AssertValidationException(ex, expectedMessages.Where(msg => msg.Contains($"{propertyName} should contain only letters and spaces")).ToList());
+        }
+        // If no validation errors are found, assert that no exception is thrown
+        else
         {
             Assert.Null(ex);
         }
-        else
-        {
-            Assert.Fail($"Unexpected result for input {input}");
-        }
     }
+
 
     public static List<string> GetValidationMessages(PropertyInfo property)
     {

--- a/P7CreateRestApi/Controllers/BidListController.cs
+++ b/P7CreateRestApi/Controllers/BidListController.cs
@@ -19,6 +19,7 @@ namespace P7CreateRestApi.Controllers
             _context = context;
         }
 
+        
         [HttpGet("list")]
         public async Task<ActionResult> GetBidLists()
         {


### PR DESCRIPTION
…removing validateMethod parameter and adding new parameters for more configurability

- add optional parameters maxLength, minLength, mandatory, NoSpecialChars, and NoNumbers to ValidateStringProperty
- remove Func<T, Action> validateMethod parameter from ValidateStringProperty
- directly call Validate method on instances implementing IValidatable interface
- update ValidateStringProperty to dynamically retrieve max length from data annotations if not provided
- refactor test methods to use the updated ValidateStringProperty without specifying the validateMethod
- improve clarity and reduce redundancy in validation logic for string properties

This change streamlines the validation testing process by leveraging the IValidatable interface and its Validate method. It also adds new parameters for more configurability and independence, enhancing maintainability and consistency across tests.

fix: implement unit tests CRUD for BidList #72 