### PR TITLE
test(Rating): Add unit tests for all Rating properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ P7CreateRestApi/logs/
 P7CreateRestApi/Migrations/20240711092136_M7.cs
 P7CreateRestApi/Migrations/20240711092136_M7.Designer.cs
 P7CreateRestApi/Migrations/LocalDbContextModelSnapshot.cs
+.vscode/
+

--- a/P7CreateRestApi.Tests/P7CreateRestApi.Tests.csproj
+++ b/P7CreateRestApi.Tests/P7CreateRestApi.Tests.csproj
@@ -20,7 +20,10 @@
     <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
     <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="coverlet.msbuild" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/P7CreateRestApi.Tests/RatingTests.cs
+++ b/P7CreateRestApi.Tests/RatingTests.cs
@@ -1,0 +1,98 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using Dot.Net.WebApi.Domain;
+
+namespace P7CreateRestApi.Tests;
+
+public class RatingTests
+{
+    // --------------- VALID DATA ------------------
+    // CurvePoint with all valid data is declarated here because it will be used in all tests
+    public Rating rating = new()
+    {
+        Id = 1,
+        MoodysRating = "MRating",
+        SandPRating = "SPRating",
+        FitchRating = "FRating",
+        OrderNumber = 1
+    };
+
+    // --------------- VALID DATA ------------------
+
+    // ALL DATA VALID
+    [Fact]
+    public void Test_Validate_WithValidRating_ShouldNotThrowException()
+    {
+        // Arrange
+
+        // Act
+        Exception? ex = Record.Exception(() => rating.Validate());
+
+        // Assert
+        Assert.Null(ex);
+    }
+
+    // --------------- NUMERIC PROPERTIES TESTS ------------------
+    
+
+    [Theory]
+    [InlineData(byte.MinValue)]
+    [InlineData(1)]
+    [InlineData(byte.MaxValue)]
+    public void Test_Validate_WithValidRating_OrderNumber_ShouldNotThrowException(byte input)
+    {
+        // Arrange
+        rating.OrderNumber = input;
+
+        // Act
+        Exception? ex = Record.Exception(() => rating.Validate());
+
+        // Assert
+        Assert.Null(ex);
+        Assert.Equal(rating.OrderNumber, input);
+    }
+
+    [Fact]
+    public void Test_Validate_WithNullRating_OrderNumber_ShouldNotThrowException()
+    {
+        // Arrange
+        rating.OrderNumber = null;
+
+        // Act
+        Exception? ex = Record.Exception(() => rating.Validate());
+
+        // Assert
+        Assert.Null(ex);
+        Assert.Null(rating.OrderNumber);
+    }
+
+    // --------------- NUMERIC PROPERTIES TESTS ------------------
+
+    // --------------- STRING PROPERTIES TESTS ------------------
+
+    // MoodysRating - 10 characters max - Mandatory
+    [Theory]
+    [MemberData(nameof(SampleTestVariables.StringCombinationsTest), MemberType = typeof(SampleTestVariables))]
+    public void Test_Validate_MoodysRating_StringVariation_ShouldReturnExpectedResults(string? input, int code)
+    {
+        TestHelper.ValidateStringProperty(rating, nameof(Rating.MoodysRating), input, code, mandatory: true);
+    }
+
+    // SandPRating - 10 characters max - Mandatory
+    [Theory]
+    [MemberData(nameof(SampleTestVariables.StringCombinationsTest), MemberType = typeof(SampleTestVariables))]
+    public void Test_Validate_SandPRating_StringVariation_ShouldReturnExpectedResults(string? input, int code)
+    {
+        TestHelper.ValidateStringProperty(rating, nameof(Rating.SandPRating), input, code, maxLength: 10, mandatory: true);
+    }
+
+    // FitchRating - 10 characters max - Mandatory
+    [Theory]
+    [MemberData(nameof(SampleTestVariables.StringCombinationsTest), MemberType = typeof(SampleTestVariables))]
+    public void Test_Validate_FitchRating_StringVariation_ShouldReturnExpectedResults(string? input, int code)
+    {
+        TestHelper.ValidateStringProperty(rating, nameof(Rating.FitchRating), input, code, maxLength: 10, mandatory: true);
+    }
+
+    // --------------- STRING PROPERTIES TESTS ------------------
+}

--- a/P7CreateRestApi.Tests/TestHelper.cs
+++ b/P7CreateRestApi.Tests/TestHelper.cs
@@ -2,6 +2,7 @@
 using System.Reflection;
 using Dot.Net.WebApi.Domain;
 
+
 namespace P7CreateRestApi.Tests;
 
 public static class TestHelper
@@ -45,7 +46,15 @@ public static class TestHelper
         PropertyInfo? property = typeof(T).GetProperty(propertyName);
 
         // Set the value of the property to the specified input string
-        property.SetValue(instance, input);
+        if (property != null)
+        {
+            // Set the value of the property to the specified input string
+            property.SetValue(instance, input);
+        }
+        else
+        {
+            throw new ArgumentException($"Property {propertyName} not found in type {typeof(T).Name}");
+        }
 
         // Get the expected validation messages for the property
         List<string> expectedMessages = GetValidationMessages(property);
@@ -55,7 +64,7 @@ public static class TestHelper
 
         // Act
 
-        // Try to validate the instance using the specified validation method
+        // Try to validate the instance using the validation method
         Exception? ex = Record.Exception(() => instance.Validate());
 
         // Assert
@@ -100,7 +109,7 @@ public static class TestHelper
     public static List<string> GetValidationMessages(PropertyInfo property)
     {
         object[] attributes = property.GetCustomAttributes(typeof(ValidationAttribute), true);
-        return attributes.Select(attr => ((ValidationAttribute)attr).ErrorMessage).ToList();
+        return attributes.Select(static attr => ((ValidationAttribute)attr).ErrorMessage).ToList();
     }
 
     public static void AssertValidationException(Exception? ex, List<string> expectedMessages)
@@ -109,9 +118,9 @@ public static class TestHelper
         Assert.IsType<ValidationException>(ex);
         ValidationException validationException = (ValidationException)ex;
 
-        bool containsExpectedMessage = expectedMessages.Any(message => validationException.Message.Contains(message));
+        bool containsExpectedMessage = expectedMessages.Exists(message => validationException.Message.Contains(message));
 
-        Assert.True(containsExpectedMessage, $"Expected one of the following messages: {string.Join(", ", expectedMessages)}. Actual message: {validationException.Message}");
+        Assert.True(containsExpectedMessage, $"Expected one of the following messages: \"{string.Join(", ", expectedMessages)}\". Actual message: \"{validationException.Message}\".");
     }
 
     public static int GetMaxLength(PropertyInfo property)
@@ -131,3 +140,7 @@ public static class TestHelper
         throw new InvalidOperationException($"The property '{property.Name}' does not have a MaxLength or StringLength attribute.");
     }
 }
+
+
+
+

--- a/P7CreateRestApi/Controllers/RatingController.cs
+++ b/P7CreateRestApi/Controllers/RatingController.cs
@@ -1,5 +1,5 @@
 ﻿using Dot.Net.WebApi;
-using Dot.Net.WebApi.Controllers.Domain;
+using Dot.Net.WebApi.Domain;
 using Dot.Net.WebApi.Data;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;

--- a/P7CreateRestApi/Data/LocalDbContext.cs
+++ b/P7CreateRestApi/Data/LocalDbContext.cs
@@ -1,5 +1,4 @@
 using Dot.Net.WebApi.Controllers;
-using Dot.Net.WebApi.Controllers.Domain;
 using Dot.Net.WebApi.Domain;
 using Dot.Net.WebApi.Models;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;

--- a/P7CreateRestApi/Domain/Rating.cs
+++ b/P7CreateRestApi/Domain/Rating.cs
@@ -1,23 +1,22 @@
 using System.ComponentModel.DataAnnotations;
-using Dot.Net.WebApi.Domain;
 
-namespace Dot.Net.WebApi.Controllers.Domain
+namespace Dot.Net.WebApi.Domain
 {
     public class Rating : IValidatable
     {
         public int Id { get; set; }
 
-        [Required(ErrorMessage = "MoodysRating is required")]
+        [Required(ErrorMessage = "MoodysRating is mandatory")]
         [DataType(DataType.Text, ErrorMessage = "MoodysRating must be a string")]
         [MaxLength(10, ErrorMessage = "MoodysRating can't be longer than 10 characters")]
         public required string MoodysRating { get; set; }
 
-        [Required(ErrorMessage = "SandPRating is required")]
+        [Required(ErrorMessage = "SandPRating is mandatory")]
         [DataType(DataType.Text, ErrorMessage = "SandPRating must be a string")]
         [MaxLength(10, ErrorMessage = "SandPRating can't be longer than 10 characters")]
         public required string SandPRating { get; set; }
 
-        [Required(ErrorMessage = "FitchRating is required")]
+        [Required(ErrorMessage = "FitchRating is mandatory")]
         [DataType(DataType.Text, ErrorMessage = "FitchRating must be a string")]
         [MaxLength(10, ErrorMessage = "FitchRating can't be longer than 10 characters")]
         public required string FitchRating { get; set; }

--- a/P7CreateRestApi/Domain/RuleName.cs
+++ b/P7CreateRestApi/Domain/RuleName.cs
@@ -1,38 +1,38 @@
 using System.ComponentModel.DataAnnotations;
 using Dot.Net.WebApi.Domain;
 
-namespace Dot.Net.WebApi.Controllers
+namespace Dot.Net.WebApi.Domain
 {
     public class RuleName : IValidatable
     {
         public int Id { get; set; }
 
-        [Required(ErrorMessage = "Name is required")]
+        [Required(ErrorMessage = "Name is mandatory")]
         [DataType(DataType.Text, ErrorMessage = "Name must be a string")]
         [MaxLength(50, ErrorMessage = "Name can't be longer than 50 characters")]
         public required string Name { get; set; }
 
-        [Required(ErrorMessage = "Description is required")]
+        [Required(ErrorMessage = "Description is mandatory")]
         [DataType(DataType.MultilineText, ErrorMessage = "Description must be a string")]
         [MaxLength(500, ErrorMessage = "Description can't be longer than 500 characters")]
         public required string Description { get; set; }
 
-        [Required(ErrorMessage = "Json is required")]
+        [Required(ErrorMessage = "Json is mandatory")]
         [DataType(DataType.MultilineText, ErrorMessage = "Json must be a string")]
         [MaxLength(5000, ErrorMessage = "Json can't be longer than 5000 characters")]
         public required string Json { get; set; }
 
-        [Required(ErrorMessage = "Template is required")]
+        [Required(ErrorMessage = "Template is mandatory")]
         [DataType(DataType.MultilineText, ErrorMessage = "Template must be a string")]
         [MaxLength(1000, ErrorMessage = "Template can't be longer than 1000 characters")]
         public required string Template { get; set; }
 
-        [Required(ErrorMessage = "SqlStr is required")]
+        [Required(ErrorMessage = "SqlStr is mandatory")]
         [DataType(DataType.MultilineText, ErrorMessage = "SqlStr must be a string")]
         [MaxLength(1000, ErrorMessage = "SqlStr can't be longer than 1000 characters")]
         public required string SqlStr { get; set; }
 
-        [Required(ErrorMessage = "SqlPart is required")]
+        [Required(ErrorMessage = "SqlPart is mandatory")]
         [DataType(DataType.MultilineText, ErrorMessage = "SqlPart must be a string")]
         [MaxLength(1000, ErrorMessage = "SqlPart can't be longer than 1000 characters")]
         public required string SqlPart { get; set; }

--- a/P7CreateRestApi/Domain/Trade.cs
+++ b/P7CreateRestApi/Domain/Trade.cs
@@ -6,12 +6,12 @@ namespace Dot.Net.WebApi.Domain
     {
         public int TradeId { get; set; }
 
-        [Required(ErrorMessage = "Account is required")]
+        [Required(ErrorMessage = "Account is mandatory")]
         [DataType(DataType.Text, ErrorMessage = "Account must be a string")]
         [MaxLength(50, ErrorMessage = "Account can't be longer than 50 characters")]
         public required string Account { get; set; }
 
-        [Required(ErrorMessage = "AccountType is required")]
+        [Required(ErrorMessage = "AccountType is mandatory")]
         [DataType(DataType.Text, ErrorMessage = "AccountType must be a string")]
         [MaxLength(50, ErrorMessage = "AccountType can't be longer than 50 characters")]
         public required string AccountType { get; set; }
@@ -31,22 +31,22 @@ namespace Dot.Net.WebApi.Domain
         [DataType(DataType.DateTime, ErrorMessage = "TradeDate must be a date and a time of day")]
         public DateTime? TradeDate { get; set; }
 
-        [Required(ErrorMessage = "TradeSecurity is required")]
+        [Required(ErrorMessage = "TradeSecurity is mandatory")]
         [DataType(DataType.Text, ErrorMessage = "TradeSecurity must be a string")]
         [MaxLength(50, ErrorMessage = "TradeSecurity can't be longer than 50 characters")]
         public required string TradeSecurity { get; set; }
 
-        [Required(ErrorMessage = "TradeStatus is required")]
+        [Required(ErrorMessage = "TradeStatus is mandatory")]
         [DataType(DataType.Text, ErrorMessage = "TradeStatus must be a string")]
         [MaxLength(50, ErrorMessage = "TradeStatus can't be longer than 50 characters")]
         public required string TradeStatus { get; set; }
 
-        [Required(ErrorMessage = "Trader is required")]
+        [Required(ErrorMessage = "Trader is mandatory")]
         [DataType(DataType.Text, ErrorMessage = "Trader must be a string")]
         [MaxLength(50, ErrorMessage = "Trader can't be longer than 50 characters")]
         public required string Trader { get; set; }
 
-        [Required(ErrorMessage = "Benchmark is required")]
+        [Required(ErrorMessage = "Benchmark is mandatory")]
         [DataType(DataType.Text, ErrorMessage = "Benchmark must be a string")]
         [MaxLength(100, ErrorMessage = "Benchmark can't be longer than 100 characters")]
         public required string Benchmark { get; set; }
@@ -56,7 +56,7 @@ namespace Dot.Net.WebApi.Domain
         [MaxLength(50, ErrorMessage = "Book can't be longer than 50 characters")]
         public required string Book { get; set; }
 
-        [Required(ErrorMessage = "CreationName is required")]
+        [Required(ErrorMessage = "CreationName is mandatory")]
         [DataType(DataType.Text, ErrorMessage = "CreationName must be a string")]
         [MaxLength(50, ErrorMessage = "CreationName can't be longer than 50 characters")]
         public required string CreationName { get; set; }
@@ -64,7 +64,7 @@ namespace Dot.Net.WebApi.Domain
         [DataType(DataType.DateTime, ErrorMessage = "CreationDate must be a date and a time of day")]
         public DateTime? CreationDate { get; set; }
 
-        [Required(ErrorMessage = "RevisionName is required")]
+        [Required(ErrorMessage = "RevisionName is mandatory")]
         [DataType(DataType.Text, ErrorMessage = "RevisionName must be a string")]
         [MaxLength(50, ErrorMessage = "RevisionName can't be longer than 50 characters")]
         public required string RevisionName { get; set; }
@@ -72,22 +72,22 @@ namespace Dot.Net.WebApi.Domain
         [DataType(DataType.DateTime, ErrorMessage = "RevisionDate must be a date and a time of day")]
         public DateTime? RevisionDate { get; set; }
 
-        [Required(ErrorMessage = "DealName is required")]
+        [Required(ErrorMessage = "DealName is mandatory")]
         [DataType(DataType.Text, ErrorMessage = "DealName must be a string")]
         [MaxLength(50, ErrorMessage = "DealName can't be longer than 50 characters")]
         public required string DealName { get; set; }
 
-        [Required(ErrorMessage = "DealType is required")]
+        [Required(ErrorMessage = "DealType is mandatory")]
         [DataType(DataType.Text, ErrorMessage = "DealType must be a string")]
         [MaxLength(50, ErrorMessage = "DealType can't be longer than 50 characters")]
         public required string DealType { get; set; }
 
-        [Required(ErrorMessage = "SourceListId is required")]
+        [Required(ErrorMessage = "SourceListId is mandatory")]
         [DataType(DataType.Text, ErrorMessage = "SourceListId must be a string")]
         [MaxLength(25, ErrorMessage = "SourceListId can't be longer than 25 characters")]
         public required string SourceListId { get; set; }
 
-        [Required(ErrorMessage = "Side is required")]
+        [Required(ErrorMessage = "Side is mandatory")]
         [DataType(DataType.Text, ErrorMessage = "Side must be a string")]
         [MaxLength(50, ErrorMessage = "Side can't be longer than 50 characters")]
         public required string Side { get; set; }

--- a/P7CreateRestApi/Domain/User.cs
+++ b/P7CreateRestApi/Domain/User.cs
@@ -5,7 +5,7 @@ namespace Dot.Net.WebApi.Domain
 {
     public class User : IdentityUser, IValidatable
     {
-        [Required(ErrorMessage = "Full name is required")]
+        [Required(ErrorMessage = "Full name is mandatory")]
         [DataType(DataType.Text)]
         [RegularExpression(@"^[a-zA-Z\s]+$", ErrorMessage = "Full name should contain only letters and spaces")]
         [StringLength(25, MinimumLength = 5, ErrorMessage = "Full name should be between 5 and 25 characters long")]


### PR DESCRIPTION
- add unit tests to cover every property of the Rating class
- standardize ErrorMessage in data annotations for all domain classes by using the term "mandatory" instead of "required"
- standardize namespaces and propagate changes
- enhance TestHelper assertion message readability
- update TestHelper to handle a new exception when setting property values

fix: Implement unit tests CRUD for Rating #27